### PR TITLE
Add indirect dependency to specific MuJoCo version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,4 +4,4 @@
 
 ### Initial release
 
-Confirmed it allows building a project for windows, mac, linux and android without need to modify the main mujoco package.  Version numbers match the mujoco release
+Confirmed it allows building a project for windows, mac, linux and android without need to modify the main mujoco package.  Version numbers match the mujoco release.

--- a/Editor/MujocoBinaries.Editor.asmdef
+++ b/Editor/MujocoBinaries.Editor.asmdef
@@ -1,0 +1,18 @@
+{
+    "name": "MujocoBinaries.Editor",
+    "rootNamespace": "",
+    "references": [
+        "GUID:62e270fc6ccbe61c59f510a8e31d067c"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Editor/MujocoBinaries.Editor.asmdef.meta
+++ b/Editor/MujocoBinaries.Editor.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6aa50684dfdc344cbbdc473a10a86da
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/ValidateMjVersion.cs
+++ b/Editor/ValidateMjVersion.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+using UnityEditor;
+using UnityEditor.PackageManager;
+using UnityEngine;
+using System.Linq;
+using UnityEditor.PackageManager.Requests;
+
+[InitializeOnLoad]
+public static class PackageVersionChecker {
+  // We could also crossref with this package's version
+  static readonly string expectedVersion = "3.3.0"; 
+  static readonly string dependencyPackage = "org.mujoco";
+  static ListRequest Request;
+
+  static PackageVersionChecker() {
+    // Run the check once on startup
+    CheckCurrentPackages();
+
+    // Also run the check whenever packages are registered (installed/updated)
+    Events.registeredPackages += OnPackagesRegistered;
+  }
+
+  static void CheckCurrentPackages() {
+    Request = Client.List(); // List packages installed for the Project
+    EditorApplication.update += Progress;
+  }
+
+  static void Progress() {
+    if (Request.IsCompleted) {
+      if (Request.Status == StatusCode.Success)
+        CheckInPackages(Request.Result);
+      else if (Request.Status >= StatusCode.Failure)
+        Debug.Log(Request.Error.message);
+
+      EditorApplication.update -= Progress;
+    }
+  }
+
+  private static void CheckInPackages(IEnumerable<UnityEditor.PackageManager.PackageInfo> packages) {
+    string dependencyVersion = null;
+    foreach (var package in packages) {
+      if (package.name == dependencyPackage)
+        dependencyVersion = package.version;
+    }
+
+    if (dependencyVersion == null) {
+      Debug.LogError($"MuJoCo package {dependencyVersion} is missing! "+
+                     $"Required version: {expectedVersion}");
+    } else if (dependencyVersion != expectedVersion) {
+      Debug.LogError($"MuJoCo version mismatch! "+
+                     $"Expected: {expectedVersion}, Found: {dependencyVersion}. "+
+                     $"Please install matching versions of the binaries and bindings.");
+    }
+  }
+
+  private static void OnPackagesRegistered(PackageRegistrationEventArgs args) {
+
+    CheckInPackages(args.added.Concat(args.changedTo));
+
+  }
+}

--- a/Editor/ValidateMjVersion.cs.meta
+++ b/Editor/ValidateMjVersion.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c0098e1d206d72e469369ac2c7dbf13d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ An important feature is that android support is also included. To compile the mu
 
 To integrate this package in your project, just add a link to in the manifest file. Make sure you point to the same MuJoCo plugin that the binaries. Current mujoco release being used is **3.3.0**
 
-To add it, the file  `manifest.json`in the packages folder should have two lines that look like this: 
+To add it alongside MuJoCo, the file  `manifest.json` in the packages folder should have two lines that look like this:
 
 ```
 "org.mujoco": "https://github.com/deepmind/mujoco.git?path=unity#3.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bin.mujoco",
-  "displayName": "MuJoCo binaries",
+  "displayName": "MuJoCo Binaries",
   "version": "3.3.0",
   "description": "MuJoCo binaries to simplify setting up a unity project with MuJoCo",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "displayName": "MuJoCo binaries",
   "version": "3.3.0",
   "description": "MuJoCo binaries to simplify setting up a unity project with MuJoCo",
-  "dependencies": {},
+  "dependencies": {
+	"org.mujoco": "3.3.0"
+  },
   "author": {
     "name" : "Joan Llobera",
     "email" : "joan.llobera@artanim.ch",


### PR DESCRIPTION
By specifying the required MuJoCo package version of the binaries, an error message will be thrown if MuJoCo is not installed. To warn of a version mismatch, I added an editor script that is evaluated once on startup, and whenever the package list changes.